### PR TITLE
Ubuntu Install instructions and wget noclobber

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ as a stand alone webserver in it self ([cherrypy.quickstart](http://docs.cherryp
 config.ini must be present in root - a copy of config.ini.example should work
 in most cases. If run under mod_wsgi: directory must be set via .htaccess - see
 .htaccess.example.
+
+### Instalation notices for specific distributions ###
+
+* [Ubuntu 15.10](./ubuntu_README.md)

--- a/lib/pirateplay/get_stream.py
+++ b/lib/pirateplay/get_stream.py
@@ -108,8 +108,9 @@ if __name__ == '__main__':
 			elif 'manifest.f4m' in stream['final_url']:
 				cmd = 'php AdobeHDS.php --delete --manifest "%s" --outfile "%s"' % (stream['final_url'], options['out_file'])
 			else:
-				cmd = 'wget -O "%s" "%s"' % (options['out_file'], ['final_url'])
-			
+				cmd = 'wget -nc -O "%s" "%s"' % (options['out_file'], ['final_url'])
+
+                        print cmd
 			if options['print_cmds']:
 				print(cmd)
 			else:

--- a/lib/pirateplay/get_stream.py
+++ b/lib/pirateplay/get_stream.py
@@ -109,8 +109,6 @@ if __name__ == '__main__':
 				cmd = 'php AdobeHDS.php --delete --manifest "%s" --outfile "%s"' % (stream['final_url'], options['out_file'])
 			else:
 				cmd = 'wget -nc -O "%s" "%s"' % (options['out_file'], ['final_url'])
-
-                        print cmd
 			if options['print_cmds']:
 				print(cmd)
 			else:

--- a/static/app.js
+++ b/static/app.js
@@ -62,7 +62,7 @@ function streamRepresentation(stream) {
 				cmd = 'php AdobeHDS.php --delete --manifest "' + streamLink + '" --outfile "' + args.out + '"';
 			}
 			else
-				cmd = "wget -O '" + args.out + "' '" + streamLink + "'";
+				cmd = "wget -nc -O '" + args.out + "' '" + streamLink + "'";
 			
 			if (args.show_inputs)
 				r.append('<input type="text" class="cmd" value=\'' + cmd + "' />");
@@ -70,10 +70,10 @@ function streamRepresentation(stream) {
 				r.append('<p class="cmd">' + cmd + '</p>');
 			if (subLink) {
 				if (args.show_inputs) {
-					subCmd = "wget -O '" + stripExt(args.out) + ".srt' '" + this.stream.meta.subtitles + "'"
+					subCmd = "wget -nc -O '" + stripExt(args.out) + ".srt' '" + this.stream.meta.subtitles + "'"
 					r.append('<input type="text" class="cmd" value=\'' + subCmd + "' />");
 				} else {
-					subCmd = "wget -O '" + stripExt(args.out) + ".srt' '" + subLink + "'"
+					subCmd = "wget -nc -O '" + stripExt(args.out) + ".srt' '" + subLink + "'"
 					r.append('<p class="cmd">' + subCmd + '</p>');
 				}
 			}

--- a/ubuntu_README.md
+++ b/ubuntu_README.md
@@ -1,0 +1,121 @@
+# (K)Ubuntu installation and configuration #
+
+These are the install and configuration instruction to get pirateplay running locally. They have been made on a new install of Kubuntu 15.10, but probably work well for all debian based distributions.
+
+## Installing dependecies
+
+Check the version
+```console
+$ python -V
+Python 2.7.10
+```
+
+Install the Python version manager
+```console
+$ sudo apt-get install python-pip
+...
+```
+
+Install the dependencies
+```console
+$ pip install cherrypy
+Downloading/unpacking cherrypy
+  Downloading CherryPy-3.8.0.tar.gz (433kB): 433kB downloaded
+  Running setup.py (path:/tmp/pip-build-OQFzMd/cherrypy/setup.py) egg_info for package cherrypy
+    
+Installing collected packages: cherrypy
+  Running setup.py install for cherrypy
+    changing mode of build/scripts-2.7/cherryd from 664 to 775
+    
+    changing mode of /home/user_name/.local/bin/cherryd to 775
+Successfully installed cherrypy
+Cleaning up...
+```
+
+```console
+$ pip install setuptools
+Downloading/unpacking setuptools
+  Downloading setuptools-18.5-py2.py3-none-any.whl (462kB): 462kB downloaded
+Installing collected packages: setuptools
+Successfully installed setuptools
+Cleaning up...
+```
+
+I got a warning when installing genshi, but things worked out anyway
+
+```console
+$ pip install genshi
+Downloading/unpacking genshi
+  Downloading Genshi-0.7.tar.gz (491kB): 491kB downloaded
+  Running setup.py (path:/tmp/pip-build-TD_zPf/genshi/setup.py) egg_info for package genshi
+    
+    warning: no previously-included files matching '*' found under directory 'doc/logo.lineform'
+    warning: no previously-included files found matching 'doc/2000ft.graffle'
+    warning: no previously-included files matching '*.pyc' found anywhere in distribution
+Installing collected packages: genshi
+  Running setup.py install for genshi
+    building 'genshi._speedups' extension
+    x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fno-strict-aliasing -D_FORTIFY_SOURCE=2 -g -fstack-protector-strong -Wformat -Werror=format
+-security -fPIC -I/usr/include/python2.7 -c genshi/_speedups.c -o build/temp.linux-x86_64-2.7/genshi/_speedups.o
+    genshi/_speedups.c:14:20: fatal error: Python.h: No such file or directory
+    compilation terminated.
+    **********************************************************************
+    WARNING:
+    An optional C extension could not be compiled, speedups will not be
+    available.
+    **********************************************************************
+    command 'x86_64-linux-gnu-gcc' failed with exit status 1
+    
+    warning: no previously-included files matching '*' found under directory 'doc/logo.lineform'
+    warning: no previously-included files found matching 'doc/2000ft.graffle'
+    warning: no previously-included files matching '*.pyc' found anywhere in distribution
+Successfully installed genshi
+Cleaning up...
+```
+
+There are several version of python packages. This one is the right one us.
+
+```console
+$ pip install python-twitter
+Downloading/unpacking python-twitter
+  Downloading python_twitter-2.2-py2-none-any.whl (60kB): 60kB downloaded
+Downloading/unpacking requests (from python-twitter)
+  Downloading requests-2.8.1-py2.py3-none-any.whl (497kB): 497kB downloaded
+Downloading/unpacking requests-oauthlib (from python-twitter)
+  Downloading requests_oauthlib-0.5.0-py2.py3-none-any.whl
+Downloading/unpacking oauthlib>=0.6.2 (from requests-oauthlib->python-twitter)
+  Downloading oauthlib-1.0.3.tar.gz (109kB): 109kB downloaded
+  Running setup.py (path:/tmp/pip-build-NL8JQF/oauthlib/setup.py) egg_info for package oauthlib
+    
+Installing collected packages: python-twitter, requests, requests-oauthlib, oauthlib
+  Running setup.py install for oauthlib
+    
+Successfully installed python-twitter requests requests-oauthlib oauthlib
+Cleaning up...
+```
+
+We also need to create the configuration file. Copy the ```config.ini.example``` in the git root directory.
+```console
+$ cp config.examle config.ini
+```
+
+This file can be used without modification to run your server locally.
+
+You can now start the server like this.
+```console
+$ python app.wsgi
+PyAMF not found! Brightcove support dissabled!
+PyAMF not found! Brightcove support dissabled!
+[13/Dec/2015:22:57:11] ENGINE Listening for SIGHUP.
+[13/Dec/2015:22:57:11] ENGINE Listening for SIGTERM.
+[13/Dec/2015:22:57:11] ENGINE Listening for SIGUSR1.
+[13/Dec/2015:22:57:11] ENGINE Bus STARTING
+[13/Dec/2015:22:57:11] ENGINE Started monitor thread '_TimeoutMonitor'.
+[13/Dec/2015:22:57:11] ENGINE Started monitor thread 'Autoreloader'.
+[13/Dec/2015:22:57:11] ENGINE Serving on http://0.0.0.0:8082
+[13/Dec/2015:22:57:11] ENGINE Bus STARTED
+```
+
+Note that although the config files states that ```server.socket_port = 80``` the server still binds this service to port ```8082```.
+
+You can now start using your service by navigatin to [http://localhost:8082](http://localhost:8082)

--- a/ubuntu_README.md
+++ b/ubuntu_README.md
@@ -73,7 +73,7 @@ Successfully installed genshi
 Cleaning up...
 ```
 
-There are several version of python packages. This one is the right one us.
+There are several version of python packages. This one is the right one for pirateplayer.
 
 ```console
 $ pip install python-twitter
@@ -94,12 +94,16 @@ Successfully installed python-twitter requests requests-oauthlib oauthlib
 Cleaning up...
 ```
 
+## Configuring the server ##
+
 We also need to create the configuration file. Copy the ```config.ini.example``` in the git root directory.
 ```console
 $ cp config.examle config.ini
 ```
 
 This file can be used without modification to run your server locally.
+
+## Starting the server ##
 
 You can now start the server like this.
 ```console


### PR DESCRIPTION
Hi,

Thanks for your updates of new formats.

This pull request adds install instructions for pirateplay.se when installing on Ubuntu 15.10
Original instructions did not seem to cover all dependencies (possibly some are missing to get a completely functioning site, but at least you can navigate to the download page).
The documentation hopefully makes it easier for people to help out if they want to.

I've also added the no clobber option to wget, so it does not overwrite file (quite common use case for me when i forget to change the target file name, either when downloading several episodes in a row, or using an old file name to get the same spelling on the base name.
